### PR TITLE
Handel CollapsibleLayer-Heading within hTag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "table-of-contents",
-  "version": "1.11.0",
+  "version": "1.10.0",
   "private": true,
   "engines": {
     "node": ">=22.14.0 < 23.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "table-of-contents",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "engines": {
     "node": ">=22.14.0 < 23.0.0"

--- a/src/webparts/tableOfContents/components/TableOfContents.tsx
+++ b/src/webparts/tableOfContents/components/TableOfContents.tsx
@@ -254,30 +254,45 @@ export default class TableOfContents extends React.Component<ITableOfContentsPro
         else {
           queryParts.push(queryItems[i] + " " + TableOfContents.h1Tag);
         }
+        if (queryItems[i] === '[data-automation-id*="CollapsibleLayer-Heading"]') {
+          queryParts.push(TableOfContents.h1Tag + ":has(" + queryItems[i] + ")");
+        }
       }
     }
 
     if (props.showHeading2) {
       for (let i = 0; i < queryItems.length; i++) {
         queryParts.push(queryItems[i] + " " + TableOfContents.h2Tag);
+        if (queryItems[i] === '[data-automation-id*="CollapsibleLayer-Heading"]') {
+          queryParts.push(TableOfContents.h2Tag + ":has(" + queryItems[i] + ")");
+        }
       }
     }
 
     if (props.showHeading3) {
       for (let i = 0; i < queryItems.length; i++) {
         queryParts.push(queryItems[i] + " " + TableOfContents.h3Tag);
+        if (queryItems[i] === '[data-automation-id*="CollapsibleLayer-Heading"]') {
+          queryParts.push(TableOfContents.h3Tag + ":has(" + queryItems[i] + ")");
+        }
       }
     }
 
     if (props.showHeading4) {
       for (let i = 0; i < queryItems.length; i++) {
         queryParts.push(queryItems[i] + " " + TableOfContents.h4Tag);
+        if (queryItems[i] === '[data-automation-id*="CollapsibleLayer-Heading"]') {
+          queryParts.push(TableOfContents.h4Tag + ":has(" + queryItems[i] + ")");
+        }
       }
     }
 
     if (props.showHeading5) {
       for (let i = 0; i < queryItems.length; i++) {
         queryParts.push(queryItems[i] + " " + TableOfContents.h5Tag);
+        if (queryItems[i] === '[data-automation-id*="CollapsibleLayer-Heading"]') {
+          queryParts.push(TableOfContents.h5Tag + ":has(" + queryItems[i] + ")");
+        }
       }
     }
 
@@ -381,6 +396,7 @@ export default class TableOfContents extends React.Component<ITableOfContentsPro
 
       const element = link.element;
       let linkText = element.innerText;
+      linkText = linkText.replace(/^[]\s*/, ''); // remove the 'Collapse' icon from the link text
       const regex = /title="Permalink for ([^"]+)"/;
 
       // If linkText is empty, extract the text from the 'Permalink'


### PR DESCRIPTION
In our SharePoint div with data-automation-id="CollapsibleLayer-Icon-left" is within h-Tag, like this:
```
<div class="headingContainer-173">
  <h3>
    <span role="button" ... data-automation-id="CollapsibleLayer-Button">  
       <div class="iconContainer-175" data-automation-id="CollapsibleLayer-Icon-left">
          ...
         <div class="titleContainer-174" data-automation-id="CollapsibleLayer-Heading">
           <div class="anchor-span">
             <span data-collapsible-section-heading-anchor="true" id="...">
               LINK TEXT
               <span class="...."></span>
           </span>
           <a ... role="link" title="Permalink for LINK TEXT" data-sp-anchor-id="..."" href="LINK" ...>...</a>
         </div>
       </div>
     </span>
   </h3>
</div>
```

This change adds these type of headings to the query-string, h-Hierachy is handled.

In Edit-Mode all Headings in Callapsible Sections are still treated as h1, no change here.